### PR TITLE
add fixing code using checkpoint files

### DIFF
--- a/siva/checkpoint_test.go
+++ b/siva/checkpoint_test.go
@@ -1,0 +1,71 @@
+package siva
+
+import (
+	"io/ioutil"
+	"os"
+	"strconv"
+	"testing"
+
+	borges "github.com/src-d/go-borges"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-billy.v4/memfs"
+	"gopkg.in/src-d/go-billy.v4/util"
+)
+
+func TestCheckpoint(t *testing.T) {
+	require := require.New(t)
+
+	sivaData, err := ioutil.ReadFile("../_testdata/siva/foo-bar.siva")
+	require.NoError(err)
+
+	fs := memfs.New()
+	lib := NewLibrary("test", fs)
+
+	var l borges.Location
+
+	// correct file
+
+	err = util.WriteFile(fs, "correct.siva", sivaData, 0666)
+	require.NoError(err)
+	l, err = lib.Location("correct")
+	require.NoError(err)
+	_, err = l.Get("github.com/foo/bar", borges.ReadOnlyMode)
+	require.NoError(err)
+
+	// broken file with correct checkpoint file
+
+	size := strconv.Itoa(len(sivaData))
+	err = util.WriteFile(fs, "broken.siva.checkpoint", []byte(size), 0666)
+	require.NoError(err)
+	brokenData := append(sivaData[:], []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}...)
+	err = util.WriteFile(fs, "broken.siva", brokenData, 0666)
+	require.NoError(err)
+	l, err = lib.Location("broken")
+	require.NoError(err)
+	_, err = l.Get("github.com/foo/bar", borges.ReadOnlyMode)
+	require.NoError(err)
+	_, err = fs.Stat("broken.siva.checkpoint")
+	require.True(os.IsNotExist(err))
+
+	// dangling checkpoint file
+
+	size = strconv.Itoa(len(sivaData))
+	err = util.WriteFile(fs, "dangling.siva.checkpoint", []byte(size), 0666)
+	require.NoError(err)
+	l, err = lib.Location("dangling")
+	require.True(borges.ErrLocationNotExists.Is(err))
+	_, err = fs.Stat("dangling.siva.checkpoint")
+	require.True(os.IsNotExist(err))
+
+	// broken siva file without checkpoint
+
+	// TODO: there's a bug in memfs and it crashes with this test. This will be
+	// enabled after it is fixed (check negative offsets in ReadAt/WriteAt).
+
+	// err = util.WriteFile(fs, "really_broken.siva", brokenData, 0666)
+	// require.NoError(err)
+	// l, err = lib.Location("really_broken")
+	// require.NoError(err)
+	// _, err = l.Get("github.com/foo/bar", borges.ReadOnlyMode)
+	// require.True(borges.ErrLocationNotExists.Is(err))
+}

--- a/siva/library.go
+++ b/siva/library.go
@@ -3,7 +3,6 @@ package siva
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	borges "github.com/src-d/go-borges"
@@ -113,16 +112,7 @@ func (l *Library) Repositories(mode borges.Mode) (borges.RepositoryIterator, err
 
 // Location implements borges.Library interface.
 func (l *Library) Location(id borges.LocationID) (borges.Location, error) {
-	return l.generateLocation(id)
-}
-
-func (l *Library) generateLocation(id borges.LocationID) (*Location, error) {
 	path := fmt.Sprintf("%s.siva", id)
-	_, err := l.fs.Stat(path)
-	if os.IsNotExist(err) {
-		return nil, borges.ErrLocationNotExists.New(id)
-	}
-
 	return NewLocation(id, l, path)
 }
 
@@ -145,7 +135,7 @@ func (l *Library) locations() ([]borges.Location, error) {
 	}
 
 	for _, s := range sivas {
-		loc, err := l.generateLocation(toLocID(s))
+		loc, err := l.Location(toLocID(s))
 		if err != nil {
 			continue
 		}

--- a/siva/repository.go
+++ b/siva/repository.go
@@ -2,9 +2,10 @@ package siva
 
 import (
 	borges "github.com/src-d/go-borges"
-	"github.com/src-d/go-borges/util"
 	billy "gopkg.in/src-d/go-billy.v4"
 	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
+	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 )
 
 type Repository struct {
@@ -24,14 +25,10 @@ func NewRepository(
 	m borges.Mode,
 	l *Location,
 ) (*Repository, error) {
-	sto, _, err := util.RepositoryStorer(fs, l.library.fs, m, l.transactional)
-	if err != nil {
-		return nil, err
-	}
-
+	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	repo, err := git.Open(sto, nil)
 	if err != nil {
-		return nil, err
+		return nil, borges.ErrLocationNotExists.New(id)
 	}
 
 	return &Repository{


### PR DESCRIPTION
If a `*.siva.checkpoint` is found it tries to fix the siva file truncating it to the size written in the checkpoint.