### PR TITLE
add transactions to repositories

### DIFF
--- a/siva/checkpoint_test.go
+++ b/siva/checkpoint_test.go
@@ -19,7 +19,7 @@ func TestCheckpoint(t *testing.T) {
 	require.NoError(err)
 
 	fs := memfs.New()
-	lib := NewLibrary("test", fs)
+	lib := NewLibrary("test", fs, true)
 
 	var l borges.Location
 

--- a/siva/library.go
+++ b/siva/library.go
@@ -13,17 +13,19 @@ import (
 
 // Library represents a borges.Library implementation based on siva files.
 type Library struct {
-	id borges.LibraryID
-	fs billy.Filesystem
+	id            borges.LibraryID
+	fs            billy.Filesystem
+	transactional bool
 }
 
 var _ borges.Library = (*Library)(nil)
 
 // NewLibrary creates a new siva.Library.
-func NewLibrary(id string, fs billy.Filesystem) *Library {
+func NewLibrary(id string, fs billy.Filesystem, transactional bool) *Library {
 	return &Library{
-		id: borges.LibraryID(id),
-		fs: fs,
+		id:            borges.LibraryID(id),
+		fs:            fs,
+		transactional: transactional,
 	}
 }
 

--- a/siva/library_test.go
+++ b/siva/library_test.go
@@ -14,7 +14,7 @@ func TestLibrary(t *testing.T) {
 	fs := osfs.New("../_testdata/siva")
 
 	s.LibrarySingle = func() borges.Library {
-		return NewLibrary("foo", fs)
+		return NewLibrary("foo", fs, false)
 	}
 
 	suite.Run(t, s)

--- a/siva/location.go
+++ b/siva/location.go
@@ -326,7 +326,7 @@ func (l *Location) writeCheckpoint() (int64, error) {
 		size = s.Size()
 	}
 
-	str := strconv.FormatInt(size, 64)
+	str := strconv.FormatInt(size, 10)
 	err = util.WriteFile(l.baseFS(), l.checkpointPath(), []byte(str), 0664)
 	if err != nil {
 		return 0, err

--- a/siva/repository.go
+++ b/siva/repository.go
@@ -2,7 +2,8 @@ package siva
 
 import (
 	borges "github.com/src-d/go-borges"
-	billy "gopkg.in/src-d/go-billy.v4"
+
+	sivafs "gopkg.in/src-d/go-billy-siva.v4"
 	git "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
@@ -11,7 +12,7 @@ import (
 type Repository struct {
 	id   borges.RepositoryID
 	repo *git.Repository
-	fs   billy.Filesystem
+	fs   sivafs.SivaFS
 	mode borges.Mode
 
 	location *Location
@@ -21,7 +22,7 @@ var _ borges.Repository = (*Repository)(nil)
 
 func NewRepository(
 	id borges.RepositoryID,
-	fs billy.Filesystem,
+	fs sivafs.SivaFS,
 	m borges.Mode,
 	l *Location,
 ) (*Repository, error) {
@@ -53,11 +54,21 @@ func (r *Repository) Mode() borges.Mode {
 }
 
 func (r *Repository) Commit() error {
-	return borges.ErrNotImplemented.New()
+	err := r.fs.Sync()
+	if err != nil {
+		return err
+	}
+
+	return r.location.Commit()
 }
 
 func (r *Repository) Close() error {
-	return borges.ErrNotImplemented.New()
+	err := r.fs.Sync()
+	if err != nil {
+		return err
+	}
+
+	return r.location.Rollback()
 }
 
 func (r *Repository) R() *git.Repository {

--- a/siva/transaction_test.go
+++ b/siva/transaction_test.go
@@ -1,0 +1,106 @@
+package siva
+
+import (
+	"io/ioutil"
+	"testing"
+
+	borges "github.com/src-d/go-borges"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-billy.v4/memfs"
+	"gopkg.in/src-d/go-billy.v4/util"
+	git "gopkg.in/src-d/go-git.v4"
+)
+
+func setupTranstaction(
+	t *testing.T,
+) (borges.Location, borges.Repository, borges.Repository) {
+	t.Helper()
+	require := require.New(t)
+
+	sivaData, err := ioutil.ReadFile("../_testdata/siva/foo-bar.siva")
+	require.NoError(err)
+
+	fs := memfs.New()
+	lib := NewLibrary("test", fs, true)
+
+	err = util.WriteFile(fs, "foo-bar.siva", sivaData, 0666)
+	require.NoError(err)
+	l, err := lib.Location("foo-bar")
+	require.NoError(err)
+
+	// open two repositories, the write one is in transaction mode
+	r, err := l.Get("github.com/foo/bar", borges.ReadOnlyMode)
+	require.NoError(err)
+	w, err := l.Get("github.com/foo/bar", borges.RWMode)
+	require.NoError(err)
+
+	return l, r, w
+}
+
+func TestCommit(t *testing.T) {
+	require := require.New(t)
+	l, r, w := setupTranstaction(t)
+
+	read := r.R()
+	write := w.R()
+
+	head, err := read.Head()
+	require.NoError(err)
+
+	// a tag created in the write repo should not be seen in the read one
+
+	_, err = write.CreateTag("new_tag", head.Hash(), nil)
+	require.NoError(err)
+
+	_, err = read.Tag("new_tag")
+	require.Equal(git.ErrTagNotFound, err)
+
+	tag, err := write.Tag("new_tag")
+	require.NoError(err)
+	require.Equal(head.Hash(), tag.Hash())
+
+	// newly repositories opened before commit should see the previous state
+
+	r, err = l.Get("github.com/foo/bar", borges.ReadOnlyMode)
+	require.NoError(err)
+
+	_, err = r.R().Tag("new_tag")
+	require.Equal(git.ErrTagNotFound, err)
+
+	err = w.Commit()
+	require.NoError(err)
+
+	// after commit the tag should still not be seen in the read repo
+
+	_, err = read.Tag("new_tag")
+	require.Equal(git.ErrTagNotFound, err)
+
+	// open the repo again and check that the tag is there
+
+	r, err = l.Get("github.com/foo/bar", borges.ReadOnlyMode)
+	require.NoError(err)
+
+	_, err = r.R().Tag("new_tag")
+	require.NoError(err)
+}
+
+func TestRollback(t *testing.T) {
+	require := require.New(t)
+	l, _, w := setupTranstaction(t)
+
+	write := w.R()
+	head, err := write.Head()
+	require.NoError(err)
+
+	_, err = write.CreateTag("new_tag", head.Hash(), nil)
+	require.NoError(err)
+
+	err = w.Close()
+	require.NoError(err)
+
+	r, err := l.Get("github.com/foo/bar", borges.ReadOnlyMode)
+	require.NoError(err)
+
+	_, err = r.R().Tag("new_tag")
+	require.Equal(git.ErrTagNotFound, err)
+}


### PR DESCRIPTION
Now library has a flag to set it transactional and is used with all
locations and repositories below it. Transaction is managed from the
location with Commit and Rollback methods. While a transaction is being
made no other transaction can start.

When a transaction starts a new siva filesystem is created for it and
the previous cachedFS kept. This way previously created repositories
from that location should work the same as before. It should also be
able to create new repositories.

**NOTE**: Needs mutexes and a way to check which repository is doing the transaction.