### PR TITLE
[DO NOT MERGE] add location registry to library

### DIFF
--- a/siva/checkpoint_test.go
+++ b/siva/checkpoint_test.go
@@ -19,7 +19,8 @@ func TestCheckpoint(t *testing.T) {
 	require.NoError(err)
 
 	fs := memfs.New()
-	lib := NewLibrary("test", fs, true)
+	lib, err := NewLibrary("test", fs, true)
+	require.NoError(err)
 
 	var l borges.Location
 

--- a/siva/checkpoint_test.go
+++ b/siva/checkpoint_test.go
@@ -19,7 +19,7 @@ func TestCheckpoint(t *testing.T) {
 	require.NoError(err)
 
 	fs := memfs.New()
-	lib, err := NewLibrary("test", fs, true)
+	lib, err := NewLibrary("test", fs, LibraryOptions{Transactional: true})
 	require.NoError(err)
 
 	var l borges.Location

--- a/siva/library.go
+++ b/siva/library.go
@@ -6,27 +6,42 @@ import (
 	"strings"
 
 	borges "github.com/src-d/go-borges"
+
 	"github.com/src-d/go-borges/util"
 	billy "gopkg.in/src-d/go-billy.v4"
 	butil "gopkg.in/src-d/go-billy.v4/util"
 )
+
+// LocationRegistrySize is the number of locations cached in the registry.
+const LocationRegistrySize = 1024
 
 // Library represents a borges.Library implementation based on siva files.
 type Library struct {
 	id            borges.LibraryID
 	fs            billy.Filesystem
 	transactional bool
+	locReg        *locationRegistry
 }
 
 var _ borges.Library = (*Library)(nil)
 
 // NewLibrary creates a new siva.Library.
-func NewLibrary(id string, fs billy.Filesystem, transactional bool) *Library {
+func NewLibrary(
+	id string,
+	fs billy.Filesystem,
+	transactional bool,
+) (*Library, error) {
+	l, err := newLocationRegistry(LocationRegistrySize)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Library{
 		id:            borges.LibraryID(id),
 		fs:            fs,
 		transactional: transactional,
-	}
+		locReg:        l,
+	}, nil
 }
 
 // ID implements borges.Library interface.
@@ -114,8 +129,19 @@ func (l *Library) Repositories(mode borges.Mode) (borges.RepositoryIterator, err
 
 // Location implements borges.Library interface.
 func (l *Library) Location(id borges.LocationID) (borges.Location, error) {
+	if loc, ok := l.locReg.Get(id); ok {
+		return loc, nil
+	}
+
 	path := fmt.Sprintf("%s.siva", id)
-	return NewLocation(id, l, path)
+	loc, err := NewLocation(id, l, path)
+	if err != nil {
+		return nil, err
+	}
+
+	l.locReg.Add(loc)
+
+	return loc, nil
 }
 
 // Locations implements borges.Library interface.
@@ -161,4 +187,12 @@ func (l *Library) Library(id borges.LibraryID) (borges.Library, error) {
 func (l *Library) Libraries() (borges.LibraryIterator, error) {
 	libs := []borges.Library{l}
 	return util.NewLibraryIterator(libs), nil
+}
+
+func (l *Library) startTransaction(loc *Location) {
+	l.locReg.StartTransaction(loc)
+}
+
+func (l *Library) endTransaction(loc *Location) {
+	l.locReg.EndTransaction(loc)
 }

--- a/siva/library.go
+++ b/siva/library.go
@@ -12,9 +12,6 @@ import (
 	butil "gopkg.in/src-d/go-billy.v4/util"
 )
 
-// LocationRegistrySize is the number of locations cached in the registry.
-const LocationRegistrySize = 1024
-
 // Library represents a borges.Library implementation based on siva files.
 type Library struct {
 	id            borges.LibraryID
@@ -23,15 +20,24 @@ type Library struct {
 	locReg        *locationRegistry
 }
 
+// LibraryOptions hold configuration options for the library.
+type LibraryOptions struct {
+	// Transactional enables transactions for repository writes.
+	Transactional bool
+	// RegistryCache is the maximum number of locations in the cache. A value
+	// of 0 disables the cache.
+	RegistryCache int
+}
+
 var _ borges.Library = (*Library)(nil)
 
 // NewLibrary creates a new siva.Library.
 func NewLibrary(
 	id string,
 	fs billy.Filesystem,
-	transactional bool,
+	ops LibraryOptions,
 ) (*Library, error) {
-	l, err := newLocationRegistry(LocationRegistrySize)
+	l, err := newLocationRegistry(ops.RegistryCache)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +45,7 @@ func NewLibrary(
 	return &Library{
 		id:            borges.LibraryID(id),
 		fs:            fs,
-		transactional: transactional,
+		transactional: ops.Transactional,
 		locReg:        l,
 	}, nil
 }

--- a/siva/library_test.go
+++ b/siva/library_test.go
@@ -5,6 +5,7 @@ import (
 
 	borges "github.com/src-d/go-borges"
 	"github.com/src-d/go-borges/test"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/src-d/go-billy.v4/osfs"
 )
@@ -14,7 +15,10 @@ func TestLibrary(t *testing.T) {
 	fs := osfs.New("../_testdata/siva")
 
 	s.LibrarySingle = func() borges.Library {
-		return NewLibrary("foo", fs, false)
+		lib, err := NewLibrary("foo", fs, false)
+		require.NoError(t, err)
+
+		return lib
 	}
 
 	suite.Run(t, s)

--- a/siva/library_test.go
+++ b/siva/library_test.go
@@ -15,7 +15,7 @@ func TestLibrary(t *testing.T) {
 	fs := osfs.New("../_testdata/siva")
 
 	s.LibrarySingle = func() borges.Library {
-		lib, err := NewLibrary("foo", fs, false)
+		lib, err := NewLibrary("foo", fs, LibraryOptions{})
 		require.NoError(t, err)
 
 		return lib

--- a/siva/locationregistry.go
+++ b/siva/locationregistry.go
@@ -1,0 +1,72 @@
+package siva
+
+import (
+	"sync"
+
+	borges "github.com/src-d/go-borges"
+
+	lru "github.com/hashicorp/golang-lru"
+)
+
+func newLocationRegistry(cacheSize int) (*locationRegistry, error) {
+	c, err := lru.New(cacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return &locationRegistry{
+		used:  make(map[borges.LocationID]*Location),
+		cache: c,
+	}, nil
+}
+
+// locationRegistry holds a list of locations that have a transaction under way
+// and recently used.
+type locationRegistry struct {
+	used  map[borges.LocationID]*Location
+	cache *lru.Cache
+
+	m sync.RWMutex
+}
+
+// Get retrieves a location from the registry.
+func (r *locationRegistry) Get(id borges.LocationID) (*Location, bool) {
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	if l, ok := r.used[id]; ok {
+		return l, true
+	}
+
+	if l, ok := r.cache.Get(id); ok {
+		return l.(*Location), true
+	}
+
+	return nil, false
+}
+
+// Add stores a location in the registry.
+func (r *locationRegistry) Add(l *Location) {
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	r.cache.Add(l.ID(), l)
+}
+
+// StartTransaction marks a location as being used so it does not get evicted.
+func (r *locationRegistry) StartTransaction(l *Location) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	r.cache.Remove(l.ID())
+	r.used[l.ID()] = l
+}
+
+// EndTransaction moves a location back to normal cache.
+func (r *locationRegistry) EndTransaction(l *Location) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	r.cache.Add(l.ID(), l)
+	delete(r.used, l.ID())
+}

--- a/siva/locationregistry_test.go
+++ b/siva/locationregistry_test.go
@@ -1,0 +1,108 @@
+package siva
+
+import (
+	"fmt"
+	"testing"
+
+	borges "github.com/src-d/go-borges"
+	"github.com/stretchr/testify/require"
+)
+
+func point(p interface{}) string {
+	return fmt.Sprintf("%p", p)
+}
+
+func TestRegistryNoCache(t *testing.T) {
+	require := require.New(t)
+
+	fs := setupFS(t)
+
+	ops := LibraryOptions{
+		Transactional: true,
+		RegistryCache: 0,
+	}
+	lib, err := NewLibrary("test", fs, ops)
+	require.NoError(err)
+
+	// locations are recreated when no transaction is being made
+
+	loc1, err := lib.Location("foo-bar")
+	require.NoError(err)
+	loc2, err := lib.Location("foo-bar")
+	require.NoError(err)
+
+	require.NotEqual(point(loc1), point(loc2))
+
+	// when there is a transaction it reuses the location
+
+	loc1, err = lib.Location("foo-bar")
+	require.NoError(err)
+
+	r, err := loc1.Get("github.com/foo/bar", borges.RWMode)
+	require.NoError(err)
+
+	loc2, err = lib.Location("foo-bar")
+	require.NoError(err)
+
+	require.Equal(point(loc1), point(loc2))
+
+	// after finishing the transaction locations are regenerated again
+
+	err = r.Close()
+	require.NoError(err)
+
+	loc2, err = lib.Location("foo-bar")
+	require.NoError(err)
+
+	require.NotEqual(point(loc1), point(loc2))
+
+	// same case but with commit
+
+	r, err = loc1.Get("github.com/foo/bar", borges.RWMode)
+	require.NoError(err)
+
+	loc2, err = lib.Location("foo-bar")
+	require.NoError(err)
+
+	require.Equal(point(loc1), point(loc2))
+
+	err = r.Commit()
+	require.NoError(err)
+
+	loc2, err = lib.Location("foo-bar")
+	require.NoError(err)
+
+	require.NotEqual(point(loc1), point(loc2))
+}
+
+func TestRegistryCache(t *testing.T) {
+	require := require.New(t)
+
+	fs := setupFS(t)
+
+	ops := LibraryOptions{
+		Transactional: true,
+		RegistryCache: 1,
+	}
+	lib, err := NewLibrary("test", fs, ops)
+	require.NoError(err)
+
+	// as the capacity is 1 getting the same location twice returns the same
+	// object
+	loc1, err := lib.Location("foo-bar")
+	require.NoError(err)
+	loc2, err := lib.Location("foo-bar")
+	require.NoError(err)
+
+	require.Equal(point(loc1), point(loc2))
+
+	// getting another location should swipe the first location from cache
+
+	_, err = lib.Location("foo-qux")
+	require.NoError(err)
+
+	loc2, err = lib.Location("foo-bar")
+	require.NoError(err)
+
+	require.NotEqual(point(loc1), point(loc2))
+}

--- a/siva/repository.go
+++ b/siva/repository.go
@@ -9,6 +9,8 @@ import (
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 )
 
+// Repository is an implementation for siva files of borges.Repository
+// interface.
 type Repository struct {
 	id   borges.RepositoryID
 	repo *git.Repository
@@ -20,6 +22,7 @@ type Repository struct {
 
 var _ borges.Repository = (*Repository)(nil)
 
+// NewRepository creates a new siva backed Repository.
 func NewRepository(
 	id borges.RepositoryID,
 	fs sivafs.SivaFS,
@@ -41,19 +44,27 @@ func NewRepository(
 	}, nil
 }
 
+// ID implements borges.Repository interface.
 func (r *Repository) ID() borges.RepositoryID {
 	return r.id
 }
 
+// LocationID implements borges.Repository interface.
 func (r *Repository) LocationID() borges.LocationID {
 	return r.location.ID()
 }
 
+// Mode implements borges.Repository interface.
 func (r *Repository) Mode() borges.Mode {
 	return r.mode
 }
 
+// Commit implements borges.Repository interface.
 func (r *Repository) Commit() error {
+	if r.mode != borges.RWMode {
+		return nil
+	}
+
 	err := r.fs.Sync()
 	if err != nil {
 		return err
@@ -62,7 +73,12 @@ func (r *Repository) Commit() error {
 	return r.location.Commit()
 }
 
+// Close implements borges.Repository interface.
 func (r *Repository) Close() error {
+	if r.mode != borges.RWMode {
+		return nil
+	}
+
 	err := r.fs.Sync()
 	if err != nil {
 		return err
@@ -71,6 +87,7 @@ func (r *Repository) Close() error {
 	return r.location.Rollback()
 }
 
+// R implements borges.Repository interface.
 func (r *Repository) R() *git.Repository {
 	return r.repo
 }

--- a/siva/transaction_test.go
+++ b/siva/transaction_test.go
@@ -2,14 +2,38 @@ package siva
 
 import (
 	"io/ioutil"
+	"path"
 	"testing"
 
 	borges "github.com/src-d/go-borges"
 	"github.com/stretchr/testify/require"
+	billy "gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-billy.v4/memfs"
 	"gopkg.in/src-d/go-billy.v4/util"
 	git "gopkg.in/src-d/go-git.v4"
 )
+
+func setupFS(t *testing.T) billy.Filesystem {
+	t.Helper()
+	require := require.New(t)
+
+	fs := memfs.New()
+
+	sivaFiles := []string{
+		"foo-bar.siva",
+		"foo-qux.siva",
+	}
+
+	for _, f := range sivaFiles {
+		path := path.Join("..", "_testdata", "siva", f)
+		sivaData, err := ioutil.ReadFile(path)
+		require.NoError(err)
+		err = util.WriteFile(fs, f, sivaData, 0666)
+		require.NoError(err)
+	}
+
+	return fs
+}
 
 func setupTranstaction(
 	t *testing.T,
@@ -17,15 +41,13 @@ func setupTranstaction(
 	t.Helper()
 	require := require.New(t)
 
-	sivaData, err := ioutil.ReadFile("../_testdata/siva/foo-bar.siva")
+	fs := setupFS(t)
+
+	lib, err := NewLibrary("test", fs, LibraryOptions{
+		Transactional: true,
+	})
 	require.NoError(err)
 
-	fs := memfs.New()
-	lib, err := NewLibrary("test", fs, true)
-	require.NoError(err)
-
-	err = util.WriteFile(fs, "foo-bar.siva", sivaData, 0666)
-	require.NoError(err)
 	l, err := lib.Location("foo-bar")
 	require.NoError(err)
 

--- a/siva/transaction_test.go
+++ b/siva/transaction_test.go
@@ -21,7 +21,8 @@ func setupTranstaction(
 	require.NoError(err)
 
 	fs := memfs.New()
-	lib := NewLibrary("test", fs, true)
+	lib, err := NewLibrary("test", fs, true)
+	require.NoError(err)
 
 	err = util.WriteFile(fs, "foo-bar.siva", sivaData, 0666)
 	require.NoError(err)


### PR DESCRIPTION
It's cache size is hardcoded for now until a library options is
implemented.

Transactions should call startTransaction and endTransaction to make
sure that subsequent Location calls return the correct location.

